### PR TITLE
ci: modernize release workflow and switch PyPI to Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,92 +4,57 @@ on:
     branches:
       - main
 
+# Serialize releases so two quick pushes to main can't race each other.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write   # semantic-release pushes the version/changelog commit and tag
+      id-token: write   # PyPI Trusted Publishing (OIDC)
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "lts/*"
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 
-      - name: Install dependencies
+      - name: Install build tooling
         run: |
           python -m pip install --upgrade pip
-          pip install build twine
+          pip install build
 
-      - name: Install semantic-release
-        run: |
-          npm install -g semantic-release @semantic-release/changelog @semantic-release/git
-
-      - name: Get Version
+      - name: Run semantic-release
         id: semantic
+        uses: cycjimmy/semantic-release-action@v4
+        with:
+          # semantic-release bumps version.py + pyproject.toml (via the exec plugin),
+          # updates CHANGELOG.md, commits + tags, and publishes the GitHub release —
+          # all in one atomic commit, so the tag matches the shipped version.
+          extra_plugins: |
+            @semantic-release/changelog
+            @semantic-release/git
+            @semantic-release/exec
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # Run semantic-release in dry-run mode and capture all output
-          output=$(npx semantic-release --dry-run --initial-version 2025.1.0 2>&1)
-          echo "Semantic Release Output:"
-          echo "$output"
-          
-          # Check for different patterns in the output
-          if echo "$output" | grep -q "Published release"; then
-            # Extract version from "Published release X.Y.Z on default channel"
-            version=$(echo "$output" | grep -oP 'Published release \K[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-            echo "new_release_version=$version" >> $GITHUB_OUTPUT
-            echo "Version to be released: $version"
-          elif echo "$output" | grep -q "next release version is"; then
-            # Extract version from "the next release version is X.Y.Z"
-            version=$(echo "$output" | grep -oP 'next release version is \K[0-9]+\.[0-9]+\.[0-9]+')
-            echo "new_release_version=$version" >> $GITHUB_OUTPUT
-            echo "Version to be released: $version"
-          else
-            echo "No new version to be released"
-            exit 0
-          fi
-
-      - name: Create Release
-        if: steps.semantic.outputs.new_release_version != ''
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npx semantic-release --initial-version 2025.1.0
-
-      - name: Update Version in Files
-        if: steps.semantic.outputs.new_release_version != ''
-        run: |
-          # Update version in version.py
-          sed -i "s/__version__ = \".*\"/__version__ = \"${{ steps.semantic.outputs.new_release_version }}\"/" src/sso_config_generator/version.py
-          
-          # Update version in pyproject.toml
-          sed -i "s/version = \".*\"/version = \"${{ steps.semantic.outputs.new_release_version }}\"/" pyproject.toml
-          
-          # Commit the version updates
-          git config --local user.email "github-actions@github.com"
-          git config --local user.name "GitHub Actions"
-          git add src/sso_config_generator/version.py pyproject.toml
-          git commit -m "chore: update version to ${{ steps.semantic.outputs.new_release_version }} [skip ci]"
-          git push
 
       - name: Build package
-        if: steps.semantic.outputs.new_release_version != ''
-        env:
-          SETUPTOOLS_SCM_PRETEND_VERSION: ${{ steps.semantic.outputs.new_release_version }}
+        if: steps.semantic.outputs.new_release_published == 'true'
         run: python -m build
 
       - name: Publish to PyPI
-        if: steps.semantic.outputs.new_release_version != ''
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-        run: twine upload dist/*
+        if: steps.semantic.outputs.new_release_published == 'true'
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.releaserc
+++ b/.releaserc
@@ -9,13 +9,13 @@
                 {"type": "feat", "release": "minor"},
                 {"type": "fix", "release": "patch"},
                 {"type": "docs", "release": "patch"},
-                {"type": "style", "release": "patch"},
                 {"type": "refactor", "release": "patch"},
                 {"type": "perf", "release": "patch"},
                 {"type": "test", "release": "patch"},
                 {"type": "build", "release": "patch"},
-                {"type": "ci", "release": "patch"},
-                {"type": "chore", "release": "patch"}
+                {"type": "chore", "release": false},
+                {"type": "ci", "release": false},
+                {"type": "style", "release": false}
             ]
         }],
         "@semantic-release/release-notes-generator",

--- a/.releaserc
+++ b/.releaserc
@@ -26,11 +26,20 @@
             }
         ],
         [
+            "@semantic-release/exec",
+            {
+                "prepareCmd": "sed -i 's/__version__ = \".*\"/__version__ = \"${nextRelease.version}\"/' src/sso_config_generator/version.py && sed -i '0,/^version = \".*\"/s//version = \"${nextRelease.version}\"/' pyproject.toml"
+            }
+        ],
+        [
             "@semantic-release/git",
             {
                 "assets": [
-                    "CHANGELOG.md"
-                ]
+                    "CHANGELOG.md",
+                    "pyproject.toml",
+                    "src/sso_config_generator/version.py"
+                ],
+                "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
             }
         ],
         "@semantic-release/github"


### PR DESCRIPTION
## Summary

Modernizes the release pipeline and fixes a real correctness bug where the git tag lagged the shipped version by one commit.

### Changes
- **Atomic version bump**: `version.py` + `pyproject.toml` are now updated inside semantic-release (via the `exec` plugin) and committed together with `CHANGELOG.md`, so the git tag matches the published version. Previously the tag was created *before* the version files were updated.
- **Removed fragile output parsing**: dropped the dry-run-then-real double run and the grep-the-stdout version extraction in favor of `cycjimmy/semantic-release-action` step outputs.
- **PyPI Trusted Publishing (OIDC)**: publish via `pypa/gh-action-pypi-publish`, dropping the long-lived `PYPI_TOKEN` secret.
- **Hardening**: explicit job `permissions`, a `release` concurrency group, and bumped `checkout`/`setup-node`/`setup-python` to current majors.
- **Less release noise**: `chore`/`ci`/`style` commits no longer cut a release.

### Required setup (done)
- PyPI trusted publisher registered for `easytocloud/sso-config-generator` workflow `release.yml`.

### Post-merge cleanup
- After the first successful OIDC release, delete the `PYPI_TOKEN` repo secret and revoke the token on PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)