### PR TITLE
ci: grant issues/PR write perms for semantic-release github plugin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,10 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     permissions:
-      contents: write   # semantic-release pushes the version/changelog commit and tag
-      id-token: write   # PyPI Trusted Publishing (OIDC)
+      contents: write        # semantic-release pushes the version/changelog commit and tag
+      issues: write          # @semantic-release/github comments on released issues
+      pull-requests: write   # @semantic-release/github comments on released PRs
+      id-token: write        # PyPI Trusted Publishing (OIDC)
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Follow-up to #3. The `@semantic-release/github` plugin comments on released issues and PRs; without `issues: write` and `pull-requests: write` those comments fail silently (the release itself still succeeds). This commit was pushed to the #3 branch just after it merged, so it didn't make it onto `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)