### PR TITLE
feat(cli): add -r/-p short flags for region and profile

### DIFF
--- a/src/sso_config_generator/cli.py
+++ b/src/sso_config_generator/cli.py
@@ -115,14 +115,14 @@ class _IniConfigCommand(click.Command):
                    'the SSO name directory is skipped automatically.')
 @click.option('--validate', is_flag=True,
               help='Validate the current AWS SSO configuration instead of generating it.')
-@click.option('--region', default='eu-west-1', show_default=True,
+@click.option('--region', '-r', default='eu-west-1', show_default=True,
               help='AWS region.')
 @click.option('--sso-session-name', default=None,
               help='Name of the [sso-session …] section to use in ~/.aws/config. '
                    'Auto-detected when exactly one such section exists, '
                    'otherwise defaults to "sso". '
                    'Useful when multiple SSO environments share the same config file.')
-@click.option('--profile', default='sso-browser', show_default=True,
+@click.option('--profile', '-p', default='sso-browser', show_default=True,
               help='AWS profile used to authenticate against SSO and AWS Organizations. '
                    'Must reference a valid sso_session in ~/.aws/config and have '
                    'permissions for sso:ListAccounts, sso:ListAccountRoles, and '


### PR DESCRIPTION
## Summary

Adds conventional short aliases for the two most frequently set options:

- `-r` → `--region`
- `-p` → `--profile`

Both map to the existing parameters — no behaviour change, no core logic touched. Verified the aliases appear in `--help` and parse correctly.

## Why now

This is the first `feat:` since the release pipeline was modernized (#3, #4), so merging it doubles as the first true end-to-end exercise of: exec-based version bump → atomic tag → build → **PyPI Trusted Publishing (OIDC)** → GitHub release. Expect a minor bump (1.8.3 → 1.9.0).

## Post-release
Once this publishes successfully via OIDC, the legacy `PYPI_TOKEN` secret can be deleted and its token revoked on PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)